### PR TITLE
Try to fix issue #12. (not tested yet)

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -932,7 +932,8 @@ namespace Skk {
                         builder.append (state.rom_kana_converter.output);
                         if (state.okuri) {
                             var prefix = Util.get_okurigana_prefix (
-                                state.okuri_rom_kana_converter.output);
+                                Util.get_hiragana (
+                                state.okuri_rom_kana_converter.output));
                             if (prefix != null) {
                                 builder.append (prefix);
                                 okuri = true;


### PR DESCRIPTION
Util.get_okurigana_prefix assumes its argument is hiragana.
So we have to Util.get_hiragana it before giving it to get_okurigana_prefix.
