### PR TITLE
Bind C-j to go back to hiragana in Azik latin

### DIFF
--- a/rules/azik/keymap/latin.json
+++ b/rules/azik/keymap/latin.json
@@ -1,10 +1,6 @@
 {
     "include": [
-        "default"
-    ],
-    "define": {
-        "keymap": {
-            "C-j": "set-input-mode-hiragana"
-        }
-    }
+        "default/latin",
+        "common"
+    ]
 }

--- a/rules/azik/keymap/wide-latin.json
+++ b/rules/azik/keymap/wide-latin.json
@@ -1,10 +1,6 @@
 {
     "include": [
-        "default"
-    ],
-    "define": {
-        "keymap": {
-            "C-j": "set-input-mode-hiragana"
-        }
-    }
+        "default/wide-latin",
+        "common"
+    ]
 }


### PR DESCRIPTION
Azik rule を利用しているとき、 latin モードで C-j を入力してもひらがなモードに戻れません。
C-j を latin と wide-latin で定義することでこの問題を解決しました。
