### PR TITLE
Show correct error for no default metadata

### DIFF
--- a/libskk/rom-kana.vala
+++ b/libskk/rom-kana.vala
@@ -192,7 +192,11 @@ namespace Skk {
 
         public RomKanaConverter () {
             try {
-                _rule = new RomKanaMapFile (Rule.find_rule ("default"));
+                var metadata = Rule.find_rule ("default");
+                if (metadata == null) {
+                    throw new RuleParseError.FAILED ("can't find default rule");
+                }
+                _rule = new RomKanaMapFile (metadata);
                 current_node = _rule.root_node;
             } catch (RuleParseError e) {
                 warning ("can't find default rom-kana rule: %s",

--- a/libskk/rule.vala
+++ b/libskk/rule.vala
@@ -262,6 +262,9 @@ namespace Skk {
             this.metadata = metadata;
 
             var default_metadata = find_rule ("default");
+            if (default_metadata == null) {
+                throw new RuleParseError.FAILED ("can't find default metadata");
+            }
             foreach (var entry in keymap_names) {
                 var _metadata = metadata;
                 if (metadata.locate_map_file ("keymap", entry.value) == null) {


### PR DESCRIPTION
The user sees segfault without handling. This marely happens, but it is hard to find the cause once happens.

I struggled with this problem, then I wish help other developers.
