### PR TITLE
Issue #33. Fix initial state of okuri ari recursive edit.

### DIFF
--- a/libskk/context.vala
+++ b/libskk/context.vala
@@ -353,7 +353,6 @@ namespace Skk {
         void start_dict_edit (string midasi, bool okuri) {
             var state = new State (_dictionaries);
             state.midasi = midasi;
-            state.okuri = okuri;
             push_state (state);
             update_preedit ();
         }
@@ -383,9 +382,9 @@ namespace Skk {
             if (dict_edit_level () > 0) {
                 var state = state_stack.peek_head ();
                 midasi = state.midasi;
-                okuri = state.okuri;
                 pop_state ();
                 state = state_stack.peek_head ();
+                okuri = state.okuri;
                 if (state.candidates.size == 0)
                     state.cancel_okuri ();
                 return true;

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -104,6 +104,8 @@ static SkkTransition okuri_ari_transitions[] =
     { SKK_INPUT_MODE_HIRAGANA, "q S i r o K u", "▼白ク", "", SKK_INPUT_MODE_KATAKANA },
     /* Issue#23 */
     { SKK_INPUT_MODE_HIRAGANA, "T e t u d a I SPC C-g", "▼手伝い", "", SKK_INPUT_MODE_HIRAGANA },
+    /* Issue#33 */
+    { SKK_INPUT_MODE_HIRAGANA, "N e o C h i SPC N", "▼ねお*ち【 ▽n】", "", SKK_INPUT_MODE_HIRAGANA },
     { 0, NULL }
   };
 


### PR DESCRIPTION
辞書登録の際okuriの有無がどう関係してくるのかまではコードを追ってませんが、これでIssue #33 の修正となるはずです。
Issueに書き込んだものと同じケースのみでテストしています。