### PR TITLE
abbrev状態でもcommit-unhandledで確定動作が行なえるように追加

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -688,6 +688,11 @@ namespace Skk {
                 state.reset ();
                 return true;
             }
+            else if (command == "commit-unhandled") {
+                state.output.assign (state.abbrev.str);
+                state.reset ();
+                return state.egg_like_newline;
+            }
             else if (key.modifiers == 0 &&
                      0x20 <= key.code && key.code <= 0x7E) {
                 state.abbrev.append_unichar (key.code);

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -174,6 +174,8 @@ static SkkTransition abbrev_transitions[] =
     { SKK_INPUT_MODE_HIRAGANA, "/ b s d 3 SPC", "▼BSD/3", "", SKK_INPUT_MODE_HIRAGANA },
     /* Issue#24 */
     { SKK_INPUT_MODE_HIRAGANA, "/ t e s t C-j", "", "test", SKK_INPUT_MODE_HIRAGANA },
+    /* Pull request#39 */
+    { SKK_INPUT_MODE_HIRAGANA, "/ t e s t C-m", "▽test", "test", SKK_INPUT_MODE_HIRAGANA },
     { 0, NULL }
   };
 


### PR DESCRIPTION
初期状態であるdefault keymapだとcommitが割り当てられているC-jのみでしか確定できませんが、これでC-mや\nで確定できるようになります