### PR TITLE
単語登録状態中にひらがな→'q'でカタカナに変換した場合、それまでに入力していた内容が消えてカタカナのみになってしまう現象の修正

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -725,7 +725,7 @@ namespace Skk {
             foreach (var entry in end_preedit_commands) {
                 if (entry.key == command) {
                     state.rom_kana_converter.output_nn_if_any ();
-                    state.output.assign (
+                    state.output.append (
                         Util.convert_by_input_mode (
                             state.rom_kana_converter.output,
                             entry.value));

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -200,6 +200,9 @@ static SkkTransition dict_edit_transitions[] =
     { SKK_INPUT_MODE_HIRAGANA, "K a t a k a n a SPC SPC K a t a k a n a q C-m", "", "カタカナ", SKK_INPUT_MODE_HIRAGANA },
     /* Issue#11 */
     { SKK_INPUT_MODE_HIRAGANA, "t a k K u n SPC", "▼っくん【】", "た", SKK_INPUT_MODE_HIRAGANA },
+    /* Pull request#41 */
+    { SKK_INPUT_MODE_HIRAGANA, "K a n j i k a t a k a n a k a n j i SPC K a n j i SPC K a t a k a n a q K a n j i SPC C-j", "▼かんじかたかなかんじ【漢字カタカナ漢字】", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "T e s u t o t e s u t o t e s u t o t e s u t o SPC t e s u t o T e s u t o q q T e s u t o q T e s u t o C-q  C-q T e s u t o q", "▼てすとてすとてすとてすと【てすとテストてすとﾃｽﾄてすと】", "", SKK_INPUT_MODE_HANKAKU_KATAKANA},
     { 0, NULL }
   };
 


### PR DESCRIPTION
修正前
```
$ echo "N i h o n b u r e i k u k o u g y o u SPC N i h o n SPC B u r e i k u q K o u g y o u SPC C-j" |skk
{ "input": "N i h o n b u r e i k u k o u g y o u SPC N i h o n SPC B u r e i k u q K o u g y o u SPC C-j", "output": "", "preedit": "▼にほんぶれいくこうぎょう【ブレイク工業】" }

$ echo "T e s u t o t e s u t o t e s u t o t e s u t o SPC t e s u t o T e s u t o q q T e s u t o q T e s u t o C-q  C-q T e s u t o q ENTER" |skk
{ "input": "T e s u t o t e s u t o t e s u t o t e s u t o SPC t e s u t o T e s u t o q q T e s u t o q T e s u t o C-q  C-q T e s u t o q ENTER", "output": "", "preedit": "▼てすとてすとてすとてすと【てすと】" }
```

修正後
```
$ echo "N i h o n b u r e i k u k o u g y o u SPC N i h o n SPC B u r e i k u q K o u g y o u SPC C-j" |skk
{ "input": "N i h o n b u r e i k u k o u g y o u SPC N i h o n SPC B u r e i k u q K o u g y o u SPC C-j", "output": "", "preedit": "▼にほんぶれいくこうぎょう【日本ブレイク工業】" }
$ echo "T e s u t o t e s u t o t e s u t o t e s u t o SPC t e s u t o T e s u t o q q T e s u t o q T e s u t o C-q  C-q T e s u t o q ENTER" |skk
{ "input": "T e s u t o t e s u t o t e s u t o t e s u t o SPC t e s u t o T e s u t o q q T e s u t o q T e s u t o C-q  C-q T e s u t o q ENTER", "output": "", "preedit": "▼てすとてすとてすとてすと【てすとテストてすとﾃｽﾄてすと】" }
```
単語登録時の自由度が上がります。
ただしこのリクエストでは単語登録時にabbrev状態を使用した場合は、
今迄と同じようにそれまで入力していた内容が消えてabbrev状態で入力し確定した内容だけになります。
```
$ echo "T e s u t o t e s u t o SPC t e s u t o / t e s t C-j ENTER"|skk
{ "input": "T e s u t o t e s u t o SPC t e s u t o / t e s t C-j ENTER", "output": "", "preedit": "▼てすとてすと【test】" }
```