### PR TITLE
travis-CIが通るようにする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: c
 
 env:
   matrix:
-    - VALAC=valac-0.24
+    - VALAC=valac
 
 before_install:
   - sudo pip install cpp-coveralls
 install:
-  - if [ "$VALAC" = "valac-0.24" ]; then
+  - if [ "$VALAC" = "valac" ]; then
       sudo add-apt-repository -y ppa:vala-team &&
       sudo apt-get update -qq &&
       sudo apt-get install -qq autotools-dev gnome-common gobject-introspection intltool libgee-0.8-dev libgirepository1.0-dev libjson-glib-dev "$VALAC";

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,42 @@
+sudo: required
+
 language: c
 
 env:
-  matrix:
-    - VALAC=valac
+  - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64"
+  - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 CFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LIBS='-ldl -lpthread'"
+  - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 CFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LIBS='-ldl -lpthread'"
+
+matrix:
+  allow_failures:
+    - env: BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 CFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LIBS='-ldl -lpthread'"
+
+services:
+  - docker
 
 before_install:
-  - sudo pip install cpp-coveralls
+  - docker pull fedora
+  - export CONTAINER=$(docker run -d fedora sleep 1800)
+  - docker exec $CONTAINER dnf -y install 'dnf-command(builddep)'
+  - docker exec $CONTAINER dnf -y builddep libskk
+  - docker exec $CONTAINER dnf -y install libtool make which
+  - docker exec $CONTAINER dnf -y install gcc-c++
+  - docker exec $CONTAINER dnf -y install libubsan
+  - docker exec $CONTAINER dnf -y install vala vala-devel
+  - docker exec $CONTAINER dnf -y install gnome-common
+  - docker exec $CONTAINER dnf -y install python-pip
+  - docker exec $CONTAINER dnf -y install git
+  - docker exec $CONTAINER useradd user
+
 install:
-  - if [ "$VALAC" = "valac" ]; then
-      sudo add-apt-repository -y ppa:vala-team &&
-      sudo apt-get update -qq &&
-      sudo apt-get install -qq autotools-dev gnome-common gobject-introspection intltool libgee-0.8-dev libgirepository1.0-dev libjson-glib-dev "$VALAC";
-    fi
+  - docker cp . $CONTAINER:/srcdir
+  - docker exec $CONTAINER chown -R user /srcdir
 
 script:
-  - ./autogen.sh --enable-code-coverage && make && make check
+  - docker exec $CONTAINER su - user sh -c "cd /srcdir && NOCONFIGURE=1 ./autogen.sh"
+  - docker exec $CONTAINER su - user sh -c "cd /srcdir && ./configure --enable-code-coverage $BUILD_OPTS"
+  - docker exec $CONTAINER su - user sh -c "cd /srcdir && make V=1 && touch po/libskk.pot && make check V=1"
+
 after_success:
-  - coveralls --exclude tools --exclude tests --gcov-options '\-lp'
+  - docker exec $CONTAINER pip install cpp-coveralls
+  - docker exec $CONTAINER su - user sh -c "cd /srcdir && coveralls --exclude tools --exclude tests --gcov-options '\-lp' -t $COVERALLS_REPO_TOKEN"


### PR DESCRIPTION
バージョン情報を指定した場合何かのAPIしかインストールされないようなのでバージョン情報を指定しないようにします。

バージョン情報が無いのは問題かもしれませんがCIが通るようにはなります。
