### PR TITLE
Add `abort-to-latin` and `abort-to-latin-unhandled` command

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -425,15 +425,15 @@ namespace Skk {
             // check abort and commit event
             if (command == "abort" ||
                 command == "abort-to-latin" ||
-                command == "abort-to-latin-passthrough") {
+                command == "abort-to-latin-unhandled") {
                 bool something_changed;
-                bool allow_passthrough;
+                bool event_handled;
                 if (state.rom_kana_converter.preedit.length > 0) {
                     something_changed = true;
                 } else {
                     something_changed = state.recursive_edit_abort ();
                 }
-                allow_passthrough = !something_changed;
+                event_handled = something_changed;
                 state.reset ();
                 if (command == "abort") {
                     return something_changed;
@@ -441,13 +441,14 @@ namespace Skk {
                 // change to latin mode
                 if (state.input_mode != InputMode.LATIN) {
                     state.input_mode = InputMode.LATIN;
-                    // this change doesn't affect `should_passthrough`
+                    // this change doesn't affect `event_handled`
                     something_changed = true;
                 }
-                // if nothing changed by "abort-to-latin-passthrough" command,
+                // if the key event will not be handled by
+                // "abort-to-latin-unhandled" command,
                 // let key event pass through
-                if (command == "abort-to-latin-passthrough" &&
-                    allow_passthrough) {
+                if (command == "abort-to-latin-unhandled" &&
+                    !event_handled) {
                     return false;
                 }
                 return something_changed;
@@ -634,7 +635,7 @@ namespace Skk {
             var command = state.lookup_key (key);
             if (command == "abort" ||
                 command == "abort-to-latin" ||
-                command == "abort-to-latin-passthrough") {
+                command == "abort-to-latin-unhandled") {
                 state.reset ();
                 return true;
             }
@@ -683,7 +684,7 @@ namespace Skk {
             var command = state.lookup_key (key);
             if (command == "abort" ||
                 command == "abort-to-latin" ||
-                command == "abort-to-latin-passthrough") {
+                command == "abort-to-latin-unhandled") {
                 state.reset ();
                 return true;
             }
@@ -745,7 +746,7 @@ namespace Skk {
             var command = state.lookup_key (key);
             if (command == "abort" ||
                 command == "abort-to-latin" ||
-                command == "abort-to-latin-passthrough") {
+                command == "abort-to-latin-unhandled") {
                 state.reset ();
                 return true;
             }
@@ -1027,7 +1028,7 @@ namespace Skk {
             }
             else if (command == "abort" ||
                      command == "abort-to-latin" ||
-                     command == "abort-to-latin-passthrough") {
+                     command == "abort-to-latin-unhandled") {
                 state.candidates.clear ();
                 state.cancel_okuri ();
                 state.handler_type = typeof (StartStateHandler);

--- a/rules/README.rules
+++ b/rules/README.rules
@@ -104,7 +104,7 @@ The current available commands are:
 abbrev
 abort
 abort-to-latin
-abort-to-latin-passthrough
+abort-to-latin-unhandled
 commit
 commit-unhandled
 complete

--- a/rules/README.rules
+++ b/rules/README.rules
@@ -103,6 +103,8 @@ The current available commands are:
 
 abbrev
 abort
+abort-to-latin
+abort-to-latin-passthrough
 commit
 commit-unhandled
 complete

--- a/tests/rules/test-aborts/keymap/hiragana.json
+++ b/tests/rules/test-aborts/keymap/hiragana.json
@@ -1,0 +1,11 @@
+{
+    "include": [
+        "default/hiragana"
+    ],
+    "define": {
+        "keymap": {
+            "C-l": "abort-to-latin",
+            "Q": "abort-to-latin-unhandled"
+        }
+    }
+}

--- a/tests/rules/test-aborts/metadata.json
+++ b/tests/rules/test-aborts/metadata.json
@@ -1,0 +1,4 @@
+{
+    "name": "abort-to-latin* test rule",
+    "description": "Test case for abort-to-latin and abort-to-latin-unhandled"
+}

--- a/tests/rules/test-aborts/rom-kana/default.json
+++ b/tests/rules/test-aborts/rom-kana/default.json
@@ -1,0 +1,3 @@
+{
+    "include": ["default/default"]
+}


### PR DESCRIPTION
This change and PR #47 (`Escape` keymap) enables us to use
"vi-cooperative" keymap.

`abort-to-latin` does "`abort`, then change to latin input mode".
If the state changes on abort or mode change, key event is consumed.

`abort-to-latin-unhandled` does "`abort`, then change to latin input
mode, and let key event pass-through when no input string is discarded".

"vi-cooperative" keymap will be achived by config such as the code below:

```json
{
  "include": [
    "default"
  ],
  "define": {
    "keymap": {
      "Escape": "abort-to-latin-unhandled",
    }
  }
}
```

`abort-to-latin-unhandled` does not consume the key event even if the
state changed.
So, when the user type "C-j Esc" under the config above, application
will receive "Esc" key event, in contrast to `abort-to-latin` command.