### PR TITLE
Let lonely modifiers pass through if no command assigned

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -423,6 +423,11 @@ namespace Skk {
                                                   ref KeyEvent key)
         {
             var command = state.lookup_key (key);
+
+            // if no command nor code is assigned to key, we can't proceed
+            if (command == null && key.code == 0)
+                return false;
+
             // check abort and commit event
             if (command == "abort" ||
                 command == "abort-to-latin" ||


### PR DESCRIPTION
This change prevents modifiers, "Control_L" without normal key for
example, from being eaten by libskk.

This is essentially doing same thing as 10555a292c2c9f45294f84a52810eff16dd901c8, except for returning `false` to let modifiers pass through.