### PR TITLE
Use consistent indentations in default keymap

### DIFF
--- a/rules/default/keymap/hankaku-katakana.json
+++ b/rules/default/keymap/hankaku-katakana.json
@@ -9,7 +9,7 @@
             "l": "set-input-mode-latin",
             "L": "set-input-mode-wide-latin",
             "C-q": "set-input-mode-hiragana",
-	    "C-j": "commit"
+            "C-j": "commit"
         }
     }
 }

--- a/rules/default/keymap/hiragana.json
+++ b/rules/default/keymap/hiragana.json
@@ -9,7 +9,7 @@
             "l": "set-input-mode-latin",
             "L": "set-input-mode-wide-latin",
             "C-q": "set-input-mode-hankaku-katakana",
-	    "C-j": "commit"
+            "C-j": "commit"
         }
     }
 }

--- a/rules/default/keymap/katakana.json
+++ b/rules/default/keymap/katakana.json
@@ -9,7 +9,7 @@
             "l": "set-input-mode-latin",
             "L": "set-input-mode-wide-latin",
             "C-q": "set-input-mode-hankaku-katakana",
-	    "C-j": "commit"
+            "C-j": "commit"
         }
     }
 }


### PR DESCRIPTION
My editor Vim is not good at showing indentation mixing spaces and tabs beautifully by default. As I want to edit the default keymap, it'd be nice if it were indented consistently.