### PR TITLE
Fix travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 
 before_install:
   - docker pull fedora
-  - export CONTAINER=$(docker run -d fedora sleep 1800)
+  - export CONTAINER=$(docker run --cap-add SYS_PTRACE -d fedora sleep 1800)
   - docker exec $CONTAINER dnf -y install 'dnf-command(builddep)'
   - docker exec $CONTAINER dnf -y builddep libskk
   - docker exec $CONTAINER dnf -y install libtool make which gcc-c++ vala vala-devel git libxkbcommon-devel $EXTRA_PKGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
 
 after_failure:
   - docker exec $CONTAINER su - user sh -c "cd /srcdir && cat tests/test-suite.log"
+  - docker exec $CONTAINER su - user sh -c "cd /srcdir && cat config.log"
 
 after_success:
   - |


### PR DESCRIPTION
これによって、masterで失敗していた#*.4のビルドが通る様になります。

通ったログ: https://travis-ci.org/github/karubabu/libskk/builds/686731395
参考: https://github.com/google/sanitizers/issues/764
参考: https://github.com/google/oss-fuzz/issues/9