### PR TITLE
Don't overwrite state.output when end_dict_edit

### DIFF
--- a/libskk/context.vala
+++ b/libskk/context.vala
@@ -396,7 +396,7 @@ namespace Skk {
                 }
                 var state = state_stack.peek_head ();
                 state.reset ();
-                state.output.assign (text);
+                state.output.append (text);
                 update_preedit ();
                 return true;
             }

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -229,6 +229,8 @@ static SkkTransition dict_edit_transitions[] =
     /* Pull request#41 */
     { SKK_INPUT_MODE_HIRAGANA, "K a n j i k a t a k a n a k a n j i SPC K a n j i SPC K a t a k a n a q K a n j i SPC C-j", "▼かんじかたかなかんじ【漢字カタカナ漢字】", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "T e s u t o t e s u t o t e s u t o t e s u t o SPC t e s u t o T e s u t o q q T e s u t o q T e s u t o C-q  C-q T e s u t o q", "▼てすとてすとてすとてすと【てすとテストてすとﾃｽﾄてすと】", "", SKK_INPUT_MODE_HANKAKU_KATAKANA},
+    /* Issue#79 */
+    { SKK_INPUT_MODE_HIRAGANA, "H o g e f u g a SPC H o g e q F u g a SPC F u g a q RET", "▼ほげふが【ホゲフガ】", "", SKK_INPUT_MODE_HIRAGANA },
     { 0, NULL }
   };
 


### PR DESCRIPTION
It fixes #79

Sorry, this PR will conflict with #78.