### PR TITLE
Fix build failure with gcc-14

### DIFF
--- a/libskk/file-dict.vala
+++ b/libskk/file-dict.vala
@@ -70,7 +70,7 @@ namespace Skk {
         // Skip until the first occurrence of line.  This moves offset
         // at the beginning of the next line.
         bool read_until (ref long offset, string line) {
-            return_val_if_fail (offset < mmap.length, null);
+            return_val_if_fail (offset < mmap.length, false);
             while (offset + line.length < mmap.length) {
                 char *p = ((char *)mmap.memory + offset);
                 if (*p == '\n' &&


### PR DESCRIPTION
The compilatoin fails with gcc-14 (`gcc (Gentoo 14.1.1_p20240518 p1) 14.1.1 20240516`).

```
In file included from /usr/include/glib-2.0/glib.h:64,
                 from /usr/include/glib-2.0/gobject/gbinding.h:30,
                 from /usr/include/glib-2.0/glib-object.h:24,
                 from ../libskk/libskk.h:6,
                 from file-dict.c:22:
file-dict.c: In function 'skk_file_dict_read_until':
/usr/include/glib-2.0/glib/gmessages.h:660:16: error: returning 'void *' from a function with return type 'gboolean' {aka 'int'} makes integer from pointer without a cast [-Wint-conversion]
  660 |         return (val); \
      |                ^
file-dict.c:339:9: note: in expansion of macro 'g_return_val_if_fail'
  339 |         g_return_val_if_fail (((gsize) (*offset)) < _tmp2_, NULL);
      |         ^~~~~~~~~~~~~~~~~~~~
```

This happen because `null` is returned where boolean is expected.