### PR TITLE
Fix act/act09 keymap

### DIFF
--- a/rules/act/keymap/hankaku-katakana.json
+++ b/rules/act/keymap/hankaku-katakana.json
@@ -1,6 +1,6 @@
 {
     "include": [
-        "default"
+        "default/hankaku-katakana"
     ],
     "define": {
         "keymap": {

--- a/rules/act/keymap/hankaku-katakana.json
+++ b/rules/act/keymap/hankaku-katakana.json
@@ -4,6 +4,7 @@
     ],
     "define": {
         "keymap": {
+            "|": "start-preedit",
             "\\": "set-input-mode-hiragana"
         }
     }

--- a/rules/act/keymap/hiragana.json
+++ b/rules/act/keymap/hiragana.json
@@ -1,6 +1,6 @@
 {
     "include": [
-        "default"
+        "default/hiragana"
     ],
     "define": {
         "keymap": {

--- a/rules/act/keymap/hiragana.json
+++ b/rules/act/keymap/hiragana.json
@@ -4,6 +4,7 @@
     ],
     "define": {
         "keymap": {
+            "|": "start-preedit",
             "\\": "set-input-mode-katakana"
         }
     }

--- a/rules/act/keymap/katakana.json
+++ b/rules/act/keymap/katakana.json
@@ -1,6 +1,6 @@
 {
     "include": [
-        "default"
+        "default/katakana"
     ],
     "define": {
         "keymap": {

--- a/rules/act/keymap/katakana.json
+++ b/rules/act/keymap/katakana.json
@@ -4,6 +4,7 @@
     ],
     "define": {
         "keymap": {
+            "|": "start-preedit",
             "\\": "set-input-mode-hiragana"
         }
     }

--- a/rules/act/keymap/latin.json
+++ b/rules/act/keymap/latin.json
@@ -1,5 +1,5 @@
 {
     "include": [
-        "default"
+        "default/latin"
     ]
 }

--- a/rules/act/keymap/wide-latin.json
+++ b/rules/act/keymap/wide-latin.json
@@ -1,5 +1,5 @@
 {
     "include": [
-        "default"
+        "default/wide-latin"
     ]
 }

--- a/rules/act09/keymap/hankaku-katakana.json
+++ b/rules/act09/keymap/hankaku-katakana.json
@@ -1,6 +1,6 @@
 {
     "include": [
-        "default"
+        "default/hankaku-katakana"
     ],
     "define": {
         "keymap": {

--- a/rules/act09/keymap/hankaku-katakana.json
+++ b/rules/act09/keymap/hankaku-katakana.json
@@ -4,6 +4,7 @@
     ],
     "define": {
         "keymap": {
+            "|": "start-preedit",
             "\\": "set-input-mode-hiragana"
         }
     }

--- a/rules/act09/keymap/hiragana.json
+++ b/rules/act09/keymap/hiragana.json
@@ -1,6 +1,6 @@
 {
     "include": [
-        "default"
+        "default/hiragana"
     ],
     "define": {
         "keymap": {

--- a/rules/act09/keymap/hiragana.json
+++ b/rules/act09/keymap/hiragana.json
@@ -4,6 +4,7 @@
     ],
     "define": {
         "keymap": {
+            "|": "start-preedit",
             "\\": "set-input-mode-katakana"
         }
     }

--- a/rules/act09/keymap/katakana.json
+++ b/rules/act09/keymap/katakana.json
@@ -1,6 +1,6 @@
 {
     "include": [
-        "default"
+        "default/katakana"
     ],
     "define": {
         "keymap": {

--- a/rules/act09/keymap/katakana.json
+++ b/rules/act09/keymap/katakana.json
@@ -4,6 +4,7 @@
     ],
     "define": {
         "keymap": {
+            "|": "start-preedit",
             "\\": "set-input-mode-hiragana"
         }
     }

--- a/rules/act09/keymap/latin.json
+++ b/rules/act09/keymap/latin.json
@@ -1,5 +1,5 @@
 {
     "include": [
-        "default"
+        "default/latin"
     ]
 }

--- a/rules/act09/keymap/wide-latin.json
+++ b/rules/act09/keymap/wide-latin.json
@@ -1,5 +1,5 @@
 {
     "include": [
-        "default"
+        "default/wide-latin"
     ]
 }


### PR DESCRIPTION
- 入力方式で act/act09 を使用中に正しく動作しない（半角からひらがなに切り替えができない、など）状態を修正
- DDSKK の挙動に合わせるために `|` で変換モードに移行するように割当（[参考](http://openlab.ring.gr.jp/skk/skk/main/skk-act.el)）

手探りの修正なので、もし意図に合わない変更であれば適宜修正していただいて大丈夫です