### PR TITLE
Add Customizable Completion Order Feature

### DIFF
--- a/libskk/Makefile.am
+++ b/libskk/Makefile.am
@@ -76,7 +76,7 @@ libskk_la_SOURCES =				\
 	expr.vala				\
 	util.vala				\
 	keysyms.vala				\
-	completion-source.vala			\
+	completion.vala			\
 	$(NULL)
 
 if HAVE_INTROSPECTION

--- a/libskk/Makefile.am
+++ b/libskk/Makefile.am
@@ -76,6 +76,7 @@ libskk_la_SOURCES =				\
 	expr.vala				\
 	util.vala				\
 	keysyms.vala				\
+	completion-source.vala			\
 	$(NULL)
 
 if HAVE_INTROSPECTION

--- a/libskk/completion-source.vala
+++ b/libskk/completion-source.vala
@@ -1,0 +1,65 @@
+using Gee;
+
+namespace Skk {
+    public abstract class CompletionSource : Object {
+        public abstract ArrayList<string> get_completions(string midasi);
+        public int priority { get; set; }
+    }
+
+    public class DictCompletionSource : CompletionSource {
+        private Dict dict;
+
+        public DictCompletionSource(Dict dict, int priority) {
+            this.dict = dict;
+            this.priority = priority;
+        }
+
+        public override ArrayList<string> get_completions(string midasi) {
+            ArrayList<string> completions = new ArrayList<string>();
+            string[] dict_completions = dict.complete(midasi);
+            if (dict_completions != null && dict_completions.length > 0) {
+                completions.add_all_array(dict_completions);
+                completions.sort((a, b) => a.collate(b));
+            }
+            return completions;
+        }
+    }
+
+    public class CompletionSourceManager {
+        private Gee.List<CompletionSource> sources = new Gee.ArrayList<CompletionSource>();
+
+        public CompletionSourceManager() {}
+
+        public void add_source(Object source_object, int priority) {
+            CompletionSource completion_source;
+            if (source_object is Dict) {
+                completion_source = new DictCompletionSource((Dict)source_object, priority);
+            } else if (source_object is CompletionSource) {
+                completion_source = (CompletionSource)source_object;
+                completion_source.priority = priority;
+            } else {
+                warning("Unsupported source type: %s", source_object.get_type().name());
+                return;
+            }
+
+            sources.add(completion_source);
+            sources.sort((a, b) => b.priority - a.priority);
+        }
+
+        public ArrayList<string> get_completions(string midasi) {
+            var completions = new ArrayList<string>();
+            var completion_set = new HashSet<string>();
+
+            foreach (var source in sources) {
+                var source_completions = source.get_completions(midasi);
+                foreach (var completion in source_completions) {
+                    if (completion_set.add(completion)) {
+                        completions.add(completion);
+                    }
+                }
+            }
+
+            return completions;
+        }
+    }
+}

--- a/libskk/completion.vala
+++ b/libskk/completion.vala
@@ -25,10 +25,10 @@ namespace Skk {
         }
     }
 
-    public class CompletionSourceManager {
+    public class CompletionService {
         private Gee.List<CompletionSource> sources = new Gee.ArrayList<CompletionSource>();
 
-        public CompletionSourceManager() {}
+        public CompletionService() {}
 
         public void add_source(Object source_object, int priority) {
             CompletionSource completion_source;

--- a/libskk/context.vala
+++ b/libskk/context.vala
@@ -717,5 +717,31 @@ namespace Skk {
             }
         }
 
+        /**
+         * Set the completion order for a specific mode.
+         *
+         * @param mode The mode to set the completion order for ("normal" or "abbrev")
+         * @param sources An array of CompletionSource objects
+         *
+         * Example usage:
+         * ```
+         * var context = new Skk.Context(dictionaries);
+         *
+         * CompletionSource[] sources = {
+         *     new DictCompletionSource(user_dict, 20),
+         *     new DictCompletionSource(system_dict, 10)
+         * };
+         *
+         * context.set_completion_order("normal", sources);
+         * context.set_completion_order("abbrev", sources);
+         * ```
+         *
+         * In this example, user_dict completions (priority 20) will be shown before
+         * system_dict completions (priority 10).
+         */
+        public void set_completion_order(string mode, CompletionSource[] sources) {
+            var state = state_stack.peek_head();
+            state.update_completion_sources(mode, sources);
+        }
     }
 }

--- a/libskk/context.vala
+++ b/libskk/context.vala
@@ -92,44 +92,6 @@ namespace Skk {
         }
 
         /**
-         * Get the current completion order for normal mode.
-         */
-        public CompletionOrder completion_order {
-            get {
-                return state_stack.peek_head().completion_order;
-            }
-            set {
-                state_stack.peek_head().completion_order = value;
-            }
-        }
-
-        /**
-         * Get the current completion order for abbrev mode.
-         */
-        public CompletionOrder completion_order_abbrev_mode {
-            get {
-                return state_stack.peek_head().completion_order_abbrev_mode;
-            }
-            set {
-                state_stack.peek_head().completion_order_abbrev_mode = value;
-            }
-        }
-
-        /**
-         * Set the completion order.
-         *
-         * @param order The completion order to set
-         * @param is_abbrev_mode Whether to set the order for abbrev mode
-         */
-        public void set_completion_order(CompletionOrder order, bool is_abbrev_mode) {
-            if (is_abbrev_mode) {
-                completion_order_abbrev_mode = order;
-            } else {
-                completion_order = order;
-            }
-        }
-
-        /**
          * Register dictionary.
          *
          * @param dict a dictionary
@@ -754,5 +716,30 @@ namespace Skk {
                 }
             }
         }
+
+        /**
+         * Get or set the current completion order for normal mode.
+         */
+        public CompletionOrder completion_order {
+            get {
+                return state_stack.peek_head().completion_order;
+            }
+            set {
+                state_stack.peek_head().completion_order = value;
+            }
+        }
+
+        /**
+         * Get or set the current completion order for abbrev mode.
+         */
+        public CompletionOrder completion_order_abbrev_mode {
+            get {
+                return state_stack.peek_head().completion_order_abbrev_mode;
+            }
+            set {
+                state_stack.peek_head().completion_order_abbrev_mode = value;
+            }
+        }
+
     }
 }

--- a/libskk/context.vala
+++ b/libskk/context.vala
@@ -92,6 +92,44 @@ namespace Skk {
         }
 
         /**
+         * Get the current completion order for normal mode.
+         */
+        public CompletionOrder completion_order {
+            get {
+                return state_stack.peek_head().completion_order;
+            }
+            set {
+                state_stack.peek_head().completion_order = value;
+            }
+        }
+
+        /**
+         * Get the current completion order for abbrev mode.
+         */
+        public CompletionOrder completion_order_abbrev_mode {
+            get {
+                return state_stack.peek_head().completion_order_abbrev_mode;
+            }
+            set {
+                state_stack.peek_head().completion_order_abbrev_mode = value;
+            }
+        }
+
+        /**
+         * Set the completion order.
+         *
+         * @param order The completion order to set
+         * @param is_abbrev_mode Whether to set the order for abbrev mode
+         */
+        public void set_completion_order(CompletionOrder order, bool is_abbrev_mode) {
+            if (is_abbrev_mode) {
+                completion_order_abbrev_mode = order;
+            } else {
+                completion_order = order;
+            }
+        }
+
+        /**
          * Register dictionary.
          *
          * @param dict a dictionary

--- a/libskk/context.vala
+++ b/libskk/context.vala
@@ -717,29 +717,5 @@ namespace Skk {
             }
         }
 
-        /**
-         * Get or set the current completion order for normal mode.
-         */
-        public CompletionOrder completion_order {
-            get {
-                return state_stack.peek_head().completion_order;
-            }
-            set {
-                state_stack.peek_head().completion_order = value;
-            }
-        }
-
-        /**
-         * Get or set the current completion order for abbrev mode.
-         */
-        public CompletionOrder completion_order_abbrev_mode {
-            get {
-                return state_stack.peek_head().completion_order_abbrev_mode;
-            }
-            set {
-                state_stack.peek_head().completion_order_abbrev_mode = value;
-            }
-        }
-
     }
 }

--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -18,13 +18,6 @@
  */
 using Gee;
 
-public enum CompletionOrder {
-    USER_DICT,
-    SYSTEM_DICT,
-    USER_DICT_THEN_SYSTEM_DICT,
-    SYSTEM_DICT_THEN_USER_DICT
-}
-
 namespace Skk {
     const string[] AUTO_START_HENKAN_KEYWORDS = {
         "を", "ヲ", "、", "。", "．", "，", "？", "」",
@@ -33,6 +26,13 @@ namespace Skk {
         "”", "】", "』", "》", "〉", "｝", "］",
         "〕", "}", "]", "?", ".", ",", "!"
     };
+
+    public enum CompletionOrder {
+        USER_DICT,
+        SYSTEM_DICT,
+        USER_DICT_THEN_SYSTEM_DICT,
+        SYSTEM_DICT_THEN_USER_DICT
+    }
 
     class State : Object {
         internal Type handler_type;
@@ -98,9 +98,6 @@ namespace Skk {
                 okuri_rom_kana_converter.period_style = value;
             }
         }
-
-        internal CompletionOrder completion_order { get; set; default = CompletionOrder.USER_DICT; }
-        internal CompletionOrder completion_order_abbrev_mode { get; set; default = CompletionOrder.USER_DICT_THEN_SYSTEM_DICT; }
 
         Rule _typing_rule;
         internal Rule typing_rule {
@@ -360,6 +357,9 @@ namespace Skk {
             }
         }
 
+        internal CompletionOrder completion_order { get; set; default = CompletionOrder.USER_DICT_THEN_SYSTEM_DICT; }
+        internal CompletionOrder completion_order_abbrev_mode { get; set; default = CompletionOrder.USER_DICT_THEN_SYSTEM_DICT; }
+
         internal void completion_start (string midasi) {
             completion.clear();
             completion_set.clear();
@@ -384,51 +384,33 @@ namespace Skk {
 
             switch (order) {
                 case CompletionOrder.USER_DICT:
-                    add_user_dict_completions(user_dict_completions);
+                    add_completions(user_dict_completions);
                     break;
                 case CompletionOrder.SYSTEM_DICT:
-                    add_system_dict_completions(system_dict_completions);
+                    add_completions(system_dict_completions);
                     break;
                 case CompletionOrder.USER_DICT_THEN_SYSTEM_DICT:
-                    add_user_dict_completions(user_dict_completions);
-                    add_system_dict_completions(system_dict_completions);
+                    add_completions(user_dict_completions);
+                    add_completions(system_dict_completions);
                     break;
                 case CompletionOrder.SYSTEM_DICT_THEN_USER_DICT:
-                    add_system_dict_completions(system_dict_completions);
-                    add_user_dict_completions(user_dict_completions);
+                    add_completions(system_dict_completions);
+                    add_completions(user_dict_completions);
                     break;
             }
 
-            // 補完候補のイテレータを設定
             completion_iterator = completion.bidir_list_iterator();
             if (!completion_iterator.first()) {
                 completion_iterator = null;
             }
         }
 
-        private void add_user_dict_completions(Gee.ArrayList<string> user_dict_completions) {
-            // ユーザー辞書の補完候補を追加(最新のものから順に)
-            for (int i = user_dict_completions.size - 1; i >= 0; i--) {
-                string word = user_dict_completions[i];
+        private void add_completions(Gee.ArrayList<string> dict_completions) {
+            dict_completions.sort();
+            foreach (string word in dict_completions) {
                 if (completion_set.add(word)) {
                     completion.add(word);
                 }
-            }
-        }
-
-        private void add_system_dict_completions(Gee.ArrayList<string> system_dict_completions) {
-            // システム辞書の補完候補をソートして追加
-            system_dict_completions.sort();
-            foreach (string word in system_dict_completions) {
-                if (completion_set.add(word)) {
-                    completion.add(word);
-                }
-            }
-
-            // 補完候補のイテレータを設定
-            completion_iterator = completion.bidir_list_iterator();
-            if (!completion_iterator.first()) {
-                completion_iterator = null;
             }
         }
 

--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -376,7 +376,8 @@ namespace Skk {
                 }
             }
 
-            // システム辞書の補完候補を追加
+            // システム辞書の補完候補をソートして追加
+            system_dict_completions.sort();
             foreach (string word in system_dict_completions) {
                 if (completion_set.add(word)) {
                     completion.add(word);

--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -77,8 +77,8 @@ namespace Skk {
         ArrayList<string> completion = new ArrayList<string> ();
         internal BidirListIterator<string> completion_iterator;
         internal Set<string> completion_set = new HashSet<string> ();
-        internal CompletionSourceManager normal_completion_source_manager = null;
-        internal CompletionSourceManager abbrev_completion_source_manager = null;
+        internal CompletionService normal_completion_service = null;
+        internal CompletionService abbrev_completion_service = null;
 
         internal string[] auto_start_henkan_keywords;
         internal string? auto_start_henkan_keyword = null;
@@ -354,41 +354,41 @@ namespace Skk {
         }
 
         internal void update_completion_sources(string mode, CompletionSource[] sources) {
-            var manager = new CompletionSourceManager();
+            var service = new CompletionService();
             foreach (var source in sources) {
-                manager.add_source(source, source.priority);
+                service.add_source(source, source.priority);
             }
 
             if (mode == "normal") {
-                normal_completion_source_manager = manager;
+                normal_completion_service = service;
             } else if (mode == "abbrev") {
-                abbrev_completion_source_manager = manager;
+                abbrev_completion_service = service;
             } else {
                 warning("Invalid mode specified: %s", mode);
             }
         }
 
         internal void completion_start (string midasi) {
-            if (normal_completion_source_manager == null) {
-                normal_completion_source_manager = new CompletionSourceManager();
+            if (normal_completion_service == null) {
+                normal_completion_service = new CompletionService();
                 foreach (var dict in dictionaries) {
-                    normal_completion_source_manager.add_source(dict, dict.read_only ? 10 : 20);
+                    normal_completion_service.add_source(dict, dict.read_only ? 10 : 20);
                 }
             }
-            if (abbrev_completion_source_manager == null) {
-                abbrev_completion_source_manager = new CompletionSourceManager();
+            if (abbrev_completion_service == null) {
+                abbrev_completion_service = new CompletionService();
                 foreach (var dict in dictionaries) {
-                    abbrev_completion_source_manager.add_source(dict, dict.read_only ? 10 : 20);
+                    abbrev_completion_service.add_source(dict, dict.read_only ? 10 : 20);
                 }
             }
 
             completion.clear();
             completion_set.clear();
 
-            var manager = (handler_type == typeof(AbbrevStateHandler)) ?
-                abbrev_completion_source_manager : normal_completion_source_manager;
+            var service = (handler_type == typeof(AbbrevStateHandler)) ?
+                abbrev_completion_service : normal_completion_service;
 
-            var completions = manager.get_completions(midasi);
+            var completions = service.get_completions(midasi);
             foreach (string word in completions) {
                 if (completion_set.add(word)) {
                     completion.add(word);

--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -353,24 +353,34 @@ namespace Skk {
             }
         }
 
-        private void ensure_completion_source_managers() {
+        internal void update_completion_sources(string mode, CompletionSource[] sources) {
+            var manager = new CompletionSourceManager();
+            foreach (var source in sources) {
+                manager.add_source(source, source.priority);
+            }
+
+            if (mode == "normal") {
+                normal_completion_source_manager = manager;
+            } else if (mode == "abbrev") {
+                abbrev_completion_source_manager = manager;
+            } else {
+                warning("Invalid mode specified: %s", mode);
+            }
+        }
+
+        internal void completion_start (string midasi) {
             if (normal_completion_source_manager == null) {
                 normal_completion_source_manager = new CompletionSourceManager();
                 foreach (var dict in dictionaries) {
                     normal_completion_source_manager.add_source(dict, dict.read_only ? 10 : 20);
                 }
             }
-
             if (abbrev_completion_source_manager == null) {
                 abbrev_completion_source_manager = new CompletionSourceManager();
                 foreach (var dict in dictionaries) {
                     abbrev_completion_source_manager.add_source(dict, dict.read_only ? 10 : 20);
                 }
             }
-        }
-
-        internal void completion_start (string midasi) {
-            ensure_completion_source_managers();
 
             completion.clear();
             completion_set.clear();


### PR DESCRIPTION
## Overview
This PR introduces a feature to libskk that allows customization of the completion candidate order from various sources, including user dictionary and system dictionary.

## Implementation Details
1. Added `CompletionSource` abstract class:
   - Includes `get_completions` method and `priority` property

2. Added `DictCompletionSource` class:
   - Implements `CompletionSource` to provide completion candidates from dictionaries

3. Added `CompletionService` class:
   - Manages multiple `CompletionSource` instances
   - Provides completion candidates in order of priority

4. Added new method to the `Context` class:
   - `set_completion_order`: Allows customization of completion order for normal and abbreviation modes

5. Updated the `State` class:
   - Modified to use `CompletionService` for retrieving completion candidates

## Default Completion Order
The default completion order for both normal mode and abbreviation mode is set to prioritize user dictionary completions over system dictionary completions.

## How to Change Completion Order
Users can change the completion order by using the `set_completion_order` method of the `Context` class. For example:

```vala
var context = new Skk.Context(dictionaries);

CompletionSource[] sources = {
    new DictCompletionSource(user_dict, 20),
    new DictCompletionSource(system_dict, 10)
};

context.set_completion_order("normal", sources);
context.set_completion_order("abbrev", sources);
```
In this example, completion candidates from the user dictionary (priority 20) will be shown before those from the system dictionary (priority 10).

## Testing Environment and Procedure
### Environment
- OS: Raspberry Pi OS (64bit)
  - OS Version:Debian GNU/Linux 12 (bookworm)
  - Kernel: Linux 6.6.47+rpt-rpi-2712
- fcitx5-skk version: fcitx5-skk/stable 5.0.14-1 arm64
- libskk0 version: 1.0.5-2

### Test Procedure
The feature was tested using the following procedure:

1. Obtain the source code:
```
apt-get source libskk0
```
This expands to `libskk-1.0.5`.

2. Update the modified files:
Copy the modified `state.vala`, `context.vala`, `completion.vala` and `Makefile.am` in libskk to `libskk-1.0.5/libskk/`.

3. Build the package:
```
cd libskk-1.0.5
debuild -us -uc -b
```

4. Install the built packages:
```
cd ..
sudo dpkg -i libskk*.deb gir1.2-skk-1.0_1.0.5-2_arm64.deb
```

5. Restart fcitx5 to apply the changes.

This testing procedure ensures that the changes are properly integrated into the existing libskk package and work correctly with fcitx5-skk.

## Related Issue
#74

## Acknowledgements

Thanks to the original author and maintainers of libskk for their great work.

Your review and feedback are appreciated.