### PR TITLE
Make "-to-latin" part of abort-to-latin(-unhandled) effective only when "abort" part is no-op

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -469,32 +469,27 @@ namespace Skk {
             if (command == "abort" ||
                 command == "abort-to-latin" ||
                 command == "abort-to-latin-unhandled") {
+                // whether or not something (will be) changed by the command
                 bool something_changed;
-                bool event_handled;
                 if (state.rom_kana_converter.preedit.length > 0) {
                     something_changed = true;
                 } else {
                     something_changed = state.recursive_edit_abort ();
                 }
-                event_handled = something_changed;
                 state.reset ();
-                if (command == "abort") {
+                if (something_changed || command == "abort") {
+                    // if the command changes the state (other than input mode),
+                    // it is expected to work as simple "abort" this time.
                     return something_changed;
                 }
-                // change to latin mode
+                // nothing to do as "abort", so change to latin mode
                 if (state.input_mode != InputMode.LATIN) {
                     state.input_mode = InputMode.LATIN;
-                    // this change doesn't affect `event_handled`
                     something_changed = true;
                 }
-                // if the key event will not be handled by
-                // "abort-to-latin-unhandled" command,
-                // let key event pass through
-                if (command == "abort-to-latin-unhandled" &&
-                    !event_handled) {
-                    return false;
-                }
-                return something_changed;
+                // abort-to-latin command should consume (handle) the key event
+                // on mode-only changes. abort-to-latin-unhandled should not.
+                return command == "abort-to-latin";
             } else if (command == "commit" ||
                        command == "commit-unhandled") {
                 bool retval;

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -545,6 +545,8 @@ abort_to_latin_commands (void) {
     { SKK_INPUT_MODE_HIRAGANA, "P o p o", "▽ぽぽ", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "P o p o SPC C-l", "▽ぽぽ", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "P o p o C-l", "", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "k y C-g", "", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "k y C-l", "", "", SKK_INPUT_MODE_HIRAGANA },
     // abort-to-latin-unhandled: Test cases with no discarded inputs.
     // In these cases, input mode should be changed to latin mode.
     // Note: While these tests cannot represent, the key event will be
@@ -553,13 +555,14 @@ abort_to_latin_commands (void) {
     { SKK_INPUT_MODE_HIRAGANA, "Q", "", "", SKK_INPUT_MODE_LATIN },
     { SKK_INPUT_MODE_HIRAGANA, "a Q", "", "あ", SKK_INPUT_MODE_LATIN },
     // abort-to-latin-unhandled: Test cases with discarded inputs.
-    // These should be exactly the same behaviour as `abort-to-latin`.
+    // These should be exactly the same behaviour as `abort-to-latin` and `abort`.
     { SKK_INPUT_MODE_HIRAGANA, "A Q", "", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "P Q", "", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "P o p Q", "", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "P o p o", "▽ぽぽ", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "P o p o SPC Q", "▽ぽぽ", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "P o p o Q", "", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "k y Q", "", "", SKK_INPUT_MODE_HIRAGANA },
     { 0, NULL }
   };
 


### PR DESCRIPTION
As stated as the comment in the test, `abort-to-latin` and `abort-to-latin-unhandled` should behave as `abort` if they discarded something in the state and `-to-latin` should be ignored in such cases.

https://github.com/ueno/libskk/blob/a7777f7e69c9d0b23a6a3e2012fdf2bcbc883e24/tests/basic.c#L540-L541

However, the current implementation changes input mode to latin even when the command discarded the non-empty preedit, causing unexpected behavior.

```
# In `myrule`, `Escape` is `abort-to-latin-unhandled`.
$ echo 'k y Escape o' | skk -r myrule
{ "input": "k y Escape o", "output": "o", "preedit": "" }
```

This patch fixes the issue.

```
# With the patch applied.
# In `myrule`, `Escape` is `abort-to-latin-unhandled`.
$ echo 'k y Escape o' | ./tools/skk -r myrule
{ "input": "k y Escape o", "output": "お", "preedit": "" }
```

In addition, refactored the related codes and comments to make it easy to understand how the abort-like commands should work.