### PR TITLE
Return to abbrev mode on abort if abbrev preedit is not empty

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -1115,7 +1115,11 @@ namespace Skk {
                      command == "abort-to-latin-unhandled") {
                 state.candidates.clear ();
                 state.cancel_okuri ();
-                state.handler_type = typeof (StartStateHandler);
+                if (state.abbrev.len > 0) {
+                    state.handler_type = typeof (AbbrevStateHandler);
+                } else {
+                    state.handler_type = typeof (StartStateHandler);
+                }
                 return true;
             }
             else {

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -123,6 +123,11 @@ static SkkTransition abort_transitions[] =
     { SKK_INPUT_MODE_HIRAGANA, "O K i C-g", "▽おき", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "O K C-g", "", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "A o i O C-g", "▽あおいお", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC", "▼メイル", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g", "▽mail", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g SPC", "▼メイル", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g e r", "▽mailer", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g e r SPC", "▼メイラー", "", SKK_INPUT_MODE_HIRAGANA },
     { 0, NULL }
   };
 


### PR DESCRIPTION
Currently, abort (or abort-\* command) on abbrev mode does not return to the state before the candidate selection mode.

````
$ echo '/ m a i l SPC' | skk
{ "input": "/ m a i l SPC", "output": "", "preedit": "▼メール" }
# ↑ Just a precondition: any candidates exist for the abbrev

$ echo '/ m a i l SPC C-g a a a a' | skk
{ "input": "/ m a i l SPC C-g a a a a", "output": "", "preedit": "▽mail" }
# ↑ expected `▽mailaaaa`, but `a a a a` after the abort (C-g) is ignored
````

This is because the abort-like commands restores the default state (`StartStateHandler`) regardless of the abbrev preedit content.

This patch fixes this issue by restoring `AbbrevStateHandler` on abort when the abbrev preedit is not empty.