### PR TITLE
Return to abbrev mode when aborting dict edit if abbrev preedit is not empty

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -1107,7 +1107,12 @@ namespace Skk {
                 state.recursive_edit_start (state.get_yomi ());
                 if (state.candidates.size == 0) {
                     state.candidates.clear ();
-                    state.handler_type = typeof (StartStateHandler);
+                    if (state.abbrev.len > 0) {
+                        state.handler_type = typeof (AbbrevStateHandler);
+                    }
+                    else {
+                        state.handler_type = typeof (StartStateHandler);
+                    }
                 }
                 return true;
             }

--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -1083,7 +1083,12 @@ namespace Skk {
             if (command == "previous-candidate") {
                 if (!state.candidates.previous ()) {
                     state.candidates.clear ();
-                    state.handler_type = typeof (StartStateHandler);
+                    if (state.abbrev.len > 0) {
+                        state.handler_type = typeof (AbbrevStateHandler);
+                    }
+                    else {
+                        state.handler_type = typeof (StartStateHandler);
+                    }
                 }
                 return true;
             }

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -123,16 +123,25 @@ static SkkTransition abort_transitions[] =
     { SKK_INPUT_MODE_HIRAGANA, "O K i C-g", "▽おき", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "O K C-g", "", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "A o i O C-g", "▽あおいお", "", SKK_INPUT_MODE_HIRAGANA },
+    /* back to abbrev state from selection mode */
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC", "▼メイル", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g", "▽mail", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g SPC", "▼メイル", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g e r", "▽mailer", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g e r SPC", "▼メイラー", "", SKK_INPUT_MODE_HIRAGANA },
+    /* back to abbrev state if dict edit started by next-candidate is aborted */
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i SPC", "▼mai【】", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i SPC C-g", "▽mai", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i SPC C-g l", "▽mail", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i SPC C-g l SPC", "▼メイル", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i SPC C-g C-g /", "▽", "", SKK_INPUT_MODE_HIRAGANA },
+    /* back to abbrev state if selection is canceled by previous-candidate */
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC", "▼メイル", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC x", "▽mail", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC x e r", "▽mailer", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC x e r SPC", "▼メイラー", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC x DEL", "▽mai", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC x C-g /", "▽", "", SKK_INPUT_MODE_HIRAGANA },
     { 0, NULL }
   };
 

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -128,6 +128,11 @@ static SkkTransition abort_transitions[] =
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g SPC", "▼メイル", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g e r", "▽mailer", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "/ m a i l SPC C-g e r SPC", "▼メイラー", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i SPC", "▼mai【】", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i SPC C-g", "▽mai", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i SPC C-g l", "▽mail", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i SPC C-g l SPC", "▼メイル", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "/ m a i SPC C-g C-g /", "▽", "", SKK_INPUT_MODE_HIRAGANA },
     { 0, NULL }
   };
 


### PR DESCRIPTION
Similar to #94, when escaping from dict edit mode by abort-like commands, it resets the state handler to `StartStateHandler`, and this lead to inconsistent state.

```
$ echo '/ m a i SPC' | skk
{ "input": "/ m a i SPC", "output": "", "preedit": "▼mai【】" }
# ↑ Just a precondition: no candidates exist for the abbrev

$ echo '/ m a i SPC C-g' | skk
{ "input": "/ m a i SPC C-g", "output": "", "preedit": "▽mai" }
# ↑ Seems correct, but internally inconsistent... See the following examples

$ echo '/ m a i SPC C-g l' | skk
{ "input": "/ m a i SPC C-g l", "output": "", "preedit": "▽mai" }
# ↑ the new input `l` is not recognized... because it is (internally) not in abbrev mode anymore

$ echo '/ m a i SPC C-g DEL' | skk
{ "input": "/ m a i SPC C-g DEL", "output": "", "preedit": "" }
# ↑ Expected `▽ma`, but it removes `▽mai` all! ... because it is not in abbrev mode anymore

$ echo '/ m a i SPC C-g DEL /' | skk
{ "input": "/ m a i SPC C-g DEL /", "output": "", "preedit": "▽mai" }
# ↑ Entering abbrev mode again, uncleared remnant of the last abbrev state revives...
```

Also, `previous-candidate` at the first candidate will cause similar issue.

```
$ echo '/ m a i l SPC x e r' | skk
{ "input": "/ m a i l SPC x e r", "output": "", "preedit": "▽mail" }
# ↑ by `x` (previous-candidate), the handler is set to `StartStateHandler`, not an `AbbrevStateHandler`
```

This patch fixes these issues by restoring `AbbrevStateHandler` when abbrev is not empty.

I suspect that `special-midasi` command might have the same issue, but I don't know what the command does, so I cannot touch that part in this patch.

https://github.com/ueno/libskk/blob/4605c9be06f91f8fa7bbdeeb41c6958bac44a328/libskk/state.vala#L1134-L1138