### PR TITLE
Use decimal digits for JIS kuten, and accept even when hyphenated

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -680,6 +680,53 @@ namespace Skk {
             }
         }
 
+        internal bool is_committable (string kuten) {
+            // committable formats:
+            //  * [D]DDDD
+            // where D is a decimal.
+            unichar c;
+            if (kuten.length == 4 || kuten.length == 5) {
+                // format: [D]DDDD
+                for (int i = 0; i < kuten.length; i++) {
+                    if (!kuten[i].isdigit ()) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        internal bool is_next_acceptable (string kuten, unichar next) {
+            unichar c;
+            if (kuten.length < 5) {
+                // format: [D]DDDD
+                for (int i = 0; i < kuten.length; i++) {
+                    if (!kuten[i].isdigit ()) {
+                        return false;
+                    }
+                }
+                return next.isdigit ();
+            }
+            return false;
+        }
+
+        internal string? parse_kuten (string kuten) {
+            if (converter != null) {
+                // format: [D]DDDD
+                var euc = parse_kuten_to_euc (kuten);
+                if (euc != null) {
+                    try {
+                        return converter.decode (euc);
+                    } catch (GLib.Error e) {
+                        warning ("can't decode %s in EUC-JP: %s",
+                                 euc, e.message);
+                    }
+                }
+            }
+            return null;
+        }
+
         int hex_char_to_int (char hex) {
             if ('0' <= hex && hex <= '9') {
                 return hex - '0';
@@ -740,17 +787,10 @@ namespace Skk {
                 return true;
             }
             else if (command == "commit-unhandled" &&
-                     (state.kuten.len == 4 || state.kuten.len == 5)) {
-                if (converter != null) {
-                    var euc = parse_kuten_to_euc (state.kuten.str);
-                    if (euc != null) {
-                        try {
-                            state.output.append (converter.decode (euc));
-                        } catch (GLib.Error e) {
-                            warning ("can't decode %s in EUC-JP: %s",
-                                     euc, e.message);
-                        }
-                    }
+                     is_committable (state.kuten.str)) {
+                var parsed = parse_kuten(state.kuten.str);
+                if (parsed != null) {
+                    state.output.append (parsed);
                 }
                 state.reset ();
                 return true;
@@ -761,8 +801,7 @@ namespace Skk {
                 return true;
             }
             else if (key.modifiers == 0 &&
-                     ('0' <= key.code && key.code <= '9') &&
-                     state.kuten.len < 5) {
+                     is_next_acceptable (state.kuten.str, key.code)) {
                 state.kuten.append_unichar (key.code);
                 return true;
             }

--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -668,12 +668,12 @@ namespace Skk {
 
         internal KutenStateHandler () {
             try {
-                // use EUC-JP to get JISX0208 characters by code
+                // use EUC-JISX0213 to get JISX0213 characters by code
                 // point, this works because EUC-JP maps JISX0208
                 // characters to equivalent bytes.  See:
                 // https://en.wikipedia.org/wiki/EUC-JP
                 // this is generally a wrong approach though
-                converter = new EncodingConverter ("EUC-JP");
+                converter = new EncodingConverter ("EUC-JISX0213");
             } catch (GLib.Error e) {
                 converter = null;
                 assert_not_reached ();
@@ -699,6 +699,36 @@ namespace Skk {
             return builder.str;
         }
 
+        internal string? parse_kuten_to_euc (string mkktt) {
+            int men;
+            if (mkktt.length == 4) {
+                men = 1;
+            }
+            else {
+                men = mkktt[0].digit_value ();
+            }
+            int ku = mkktt[mkktt.length - 3].digit_value ();
+            int ten = mkktt[mkktt.length - 1].digit_value ();
+            if (men < 1 || men > 3 || ku < 0 || ten < 0) {
+                warning ("invalid kuten %s", mkktt);
+                return null;
+            }
+            ku += 10 * mkktt[mkktt.length - 4].digit_value ();
+            ten += 10 * mkktt[mkktt.length - 2].digit_value ();
+            if (ku < 1 || ku > 94 || ten < 1 || ten > 94) {
+                warning ("invalid kuten %s", mkktt);
+                return null;
+            }
+            var builder = new StringBuilder ();
+            if (men == 2) {
+                builder.append_c (0x8F);
+            }
+            // map 1--94 to 0xA1--0xFE.
+            builder.append_c ((char)ku + 0xA0);
+            builder.append_c ((char)ten + 0xA0);
+            return builder.str;
+        }
+
         internal override bool process_key_event (State state,
                                                   ref KeyEvent key)
         {
@@ -710,14 +740,16 @@ namespace Skk {
                 return true;
             }
             else if (command == "commit-unhandled" &&
-                     (state.kuten.len == 4 || state.kuten.len == 6)) {
+                     (state.kuten.len == 4 || state.kuten.len == 5)) {
                 if (converter != null) {
-                    var euc = parse_hex (state.kuten.str);
-                    try {
-                        state.output.append (converter.decode (euc));
-                    } catch (GLib.Error e) {
-                        warning ("can't decode %s in EUC-JP: %s",
-                                 euc, e.message);
+                    var euc = parse_kuten_to_euc (state.kuten.str);
+                    if (euc != null) {
+                        try {
+                            state.output.append (converter.decode (euc));
+                        } catch (GLib.Error e) {
+                            warning ("can't decode %s in EUC-JP: %s",
+                                     euc, e.message);
+                        }
                     }
                 }
                 state.reset ();
@@ -729,10 +761,8 @@ namespace Skk {
                 return true;
             }
             else if (key.modifiers == 0 &&
-                       (('a' <= key.code && key.code <= 'f') ||
-                        ('A' <= key.code && key.code <= 'F') ||
-                        ('0' <= key.code && key.code <= '9')) &&
-                       state.kuten.len < 6) {
+                     ('0' <= key.code && key.code <= '9') &&
+                     state.kuten.len < 5) {
                 state.kuten.append_unichar (key.code);
                 return true;
             }
@@ -743,7 +773,7 @@ namespace Skk {
                                               out uint underline_offset,
                                               out uint underline_nchars) {
             underline_offset = underline_nchars = 0;
-            return _("Kuten([MM]KKTT) ") + state.kuten.str;
+            return _("Kuten([M]KKTT) ") + state.kuten.str;
         }
     }
 

--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -168,8 +168,11 @@ namespace Skk {
                     """
                     # [D]DDDD ([M]KKTT)
                     ^(?P<men>\d)?(?P<ku>\d{2})(?P<ten>\d{2})$
+                    |
+                    # [D-][D]D-[D]D ([M-][K]K-[T]T)
+                    ^(?:(?P<men>\d)-)?(?P<ku>\d{1,2})-(?P<ten>\d{1,2})$
                     """,
-                    RegexCompileFlags.EXTENDED);
+                    RegexCompileFlags.EXTENDED | RegexCompileFlags.DUPNAMES);
             } catch (GLib.RegexError e) {
                 assert_not_reached ();
             }
@@ -826,7 +829,13 @@ namespace Skk {
                                               out uint underline_offset,
                                               out uint underline_nchars) {
             underline_offset = underline_nchars = 0;
-            return _("Kuten([M]KKTT) ") + state.kuten.str;
+            if ((state.kuten.len >= 2 && state.kuten.str[1] == '-') ||
+                (state.kuten.len >= 3 && state.kuten.str[2] == '-')) {
+                return _("Kuten([M-][K]K-[T]T) ") + state.kuten.str;
+            }
+            else {
+                return _("Kuten([M]KKTT) ") + state.kuten.str;
+            }
         }
     }
 

--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -134,6 +134,7 @@ namespace Skk {
 
         Regex numeric_regex;
         Regex numeric_ref_regex;
+        internal Regex kuten_regex;
 
         internal State (Gee.List<Dict> dictionaries) {
             this.dictionaries = dictionaries;
@@ -158,6 +159,12 @@ namespace Skk {
 
             try {
                 numeric_ref_regex = new Regex ("#([0-9])");
+            } catch (GLib.RegexError e) {
+                assert_not_reached ();
+            }
+
+            try {
+                kuten_regex = new Regex ("""^\d{4,5}$""");
             } catch (GLib.RegexError e) {
                 assert_not_reached ();
             }
@@ -680,35 +687,28 @@ namespace Skk {
             }
         }
 
-        internal bool is_committable (string kuten) {
+        internal bool is_committable (State state) {
             // committable formats:
             //  * [D]DDDD
             // where D is a decimal.
-            unichar c;
-            if (kuten.length == 4 || kuten.length == 5) {
-                // format: [D]DDDD
-                for (int i = 0; i < kuten.length; i++) {
-                    if (!kuten[i].isdigit ()) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-            return false;
+            return state.kuten_regex.match (state.kuten.str);
         }
 
-        internal bool is_next_acceptable (string kuten, unichar next) {
-            unichar c;
-            if (kuten.length < 5) {
-                // format: [D]DDDD
-                for (int i = 0; i < kuten.length; i++) {
-                    if (!kuten[i].isdigit ()) {
-                        return false;
-                    }
-                }
-                return next.isdigit ();
+        internal bool append_if_acceptable (State state, unichar next) {
+            size_t old_len = state.kuten.len;
+            state.kuten.append_unichar (next);
+
+            MatchInfo match_info;
+            bool matched = state.kuten_regex.match (
+                state.kuten.str,
+                RegexMatchFlags.PARTIAL_HARD,
+                out match_info);
+            bool acceptable = matched || match_info.is_partial_match ();
+            if (!acceptable) {
+                // restore the original kuten content.
+                state.kuten.truncate (old_len);
             }
-            return false;
+            return acceptable;
         }
 
         internal string? parse_kuten (string kuten) {
@@ -787,7 +787,7 @@ namespace Skk {
                 return true;
             }
             else if (command == "commit-unhandled" &&
-                     is_committable (state.kuten.str)) {
+                     is_committable (state)) {
                 var parsed = parse_kuten(state.kuten.str);
                 if (parsed != null) {
                     state.output.append (parsed);
@@ -801,8 +801,7 @@ namespace Skk {
                 return true;
             }
             else if (key.modifiers == 0 &&
-                     is_next_acceptable (state.kuten.str, key.code)) {
-                state.kuten.append_unichar (key.code);
+                     append_if_acceptable (state, key.code)) {
                 return true;
             }
             return true;

--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -164,7 +164,12 @@ namespace Skk {
             }
 
             try {
-                kuten_regex = new Regex ("""^\d{4,5}$""");
+                kuten_regex = new Regex (
+                    """
+                    # [D]DDDD ([M]KKTT)
+                    ^(?P<men>\d)?(?P<ku>\d{2})(?P<ten>\d{2})$
+                    """,
+                    RegexCompileFlags.EXTENDED);
             } catch (GLib.RegexError e) {
                 assert_not_reached ();
             }
@@ -687,23 +692,20 @@ namespace Skk {
             }
         }
 
-        internal bool is_committable (State state) {
-            // committable formats:
-            //  * [D]DDDD
-            // where D is a decimal.
-            return state.kuten_regex.match (state.kuten.str);
+        internal bool is_committable (State state, out MatchInfo match_info) {
+            return state.kuten_regex.match (state.kuten.str, 0, out match_info);
         }
 
         internal bool append_if_acceptable (State state, unichar next) {
             size_t old_len = state.kuten.len;
             state.kuten.append_unichar (next);
 
-            MatchInfo match_info;
+            MatchInfo info;
             bool matched = state.kuten_regex.match (
                 state.kuten.str,
                 RegexMatchFlags.PARTIAL_HARD,
-                out match_info);
-            bool acceptable = matched || match_info.is_partial_match ();
+                out info);
+            bool acceptable = matched || info.is_partial_match ();
             if (!acceptable) {
                 // restore the original kuten content.
                 state.kuten.truncate (old_len);
@@ -711,17 +713,56 @@ namespace Skk {
             return acceptable;
         }
 
-        internal string? parse_kuten (string kuten) {
-            if (converter != null) {
-                // format: [D]DDDD
-                var euc = parse_kuten_to_euc (kuten);
-                if (euc != null) {
-                    try {
-                        return converter.decode (euc);
-                    } catch (GLib.Error e) {
-                        warning ("can't decode %s in EUC-JP: %s",
-                                 euc, e.message);
-                    }
+        internal string? parse_kuten (State state, MatchInfo info) {
+            assert (converter != null);
+
+            int start_pos = 0, end_pos = 0;
+            info.fetch_named_pos ("ku", out start_pos, out end_pos);
+            if (start_pos >= 0) {
+                // format:
+                //  * [M]KKTT
+                //  * [M-][K]K-[T]T
+                int ku = state.kuten.str[start_pos].digit_value ();
+                if (end_pos - start_pos == 2) {
+                    ku = 10 * ku +
+                        state.kuten.str[start_pos + 1].digit_value ();
+                }
+
+                info.fetch_named_pos ("ten", out start_pos, out end_pos);
+                assert(start_pos >= 0);
+                int ten = state.kuten.str[start_pos].digit_value ();
+                if (end_pos - start_pos == 2) {
+                    ten = 10 * ten +
+                        state.kuten.str[start_pos + 1].digit_value ();
+                }
+
+                info.fetch_named_pos ("men", out start_pos, out end_pos);
+                int men = 1;
+                if (start_pos >= 0) {
+                    warn_if_fail (end_pos - start_pos == 1);
+                    men = state.kuten.str[start_pos].digit_value ();
+                }
+
+                // validate range roughly
+                if (!(1 <= men && men <= 2 && 1 <= ku && ku <= 94 &&
+                      1 <= ten && ten <= 94)) {
+                    warning ("invalid kuten %d-%d-%d", men, ku, ten);
+                    return null;
+                }
+
+                // build a character through EUC-JP encoding
+                var euc_builder = new StringBuilder ();
+                if (men == 2) {
+                    euc_builder.append_c (0x8F);
+                }
+                // map 1--94 to 0xA1--0xFE.
+                euc_builder.append_c ((char)ku + 0xA0);
+                euc_builder.append_c ((char)ten + 0xA0);
+                try {
+                    return converter.decode (euc_builder.str);
+                } catch (GLib.Error e) {
+                    warning ("can't decode %s in EUC-JP: %s",
+                             euc_builder.str, e.message);
                 }
             }
             return null;
@@ -746,39 +787,10 @@ namespace Skk {
             return builder.str;
         }
 
-        internal string? parse_kuten_to_euc (string mkktt) {
-            int men;
-            if (mkktt.length == 4) {
-                men = 1;
-            }
-            else {
-                men = mkktt[0].digit_value ();
-            }
-            int ku = mkktt[mkktt.length - 3].digit_value ();
-            int ten = mkktt[mkktt.length - 1].digit_value ();
-            if (men < 1 || men > 3 || ku < 0 || ten < 0) {
-                warning ("invalid kuten %s", mkktt);
-                return null;
-            }
-            ku += 10 * mkktt[mkktt.length - 4].digit_value ();
-            ten += 10 * mkktt[mkktt.length - 2].digit_value ();
-            if (ku < 1 || ku > 94 || ten < 1 || ten > 94) {
-                warning ("invalid kuten %s", mkktt);
-                return null;
-            }
-            var builder = new StringBuilder ();
-            if (men == 2) {
-                builder.append_c (0x8F);
-            }
-            // map 1--94 to 0xA1--0xFE.
-            builder.append_c ((char)ku + 0xA0);
-            builder.append_c ((char)ten + 0xA0);
-            return builder.str;
-        }
-
         internal override bool process_key_event (State state,
                                                   ref KeyEvent key)
         {
+            MatchInfo kuten_match_info = null;
             var command = state.lookup_key (key);
             if (command == "abort" ||
                 command == "abort-to-latin" ||
@@ -787,8 +799,11 @@ namespace Skk {
                 return true;
             }
             else if (command == "commit-unhandled" &&
-                     is_committable (state)) {
-                var parsed = parse_kuten(state.kuten.str);
+                     is_committable (state, out kuten_match_info)) {
+                // if committable, `is_committable()` returns the match info.
+                assert(kuten_match_info != null);
+
+                var parsed = parse_kuten(state, kuten_match_info);
                 if (parsed != null) {
                     state.output.append (parsed);
                 }

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libskk 0.0.1\n"
 "Report-Msgid-Bugs-To: ueno@gnu.org\n"
-"POT-Creation-Date: 2026-03-24 09:37+0900\n"
+"POT-Creation-Date: 2026-03-24 09:39+0900\n"
 "PO-Revision-Date: 2014-03-06 18:39+0900\n"
 "Last-Translator: Daiki Ueno <ueno@unixuser.org>\n"
 "Language-Team: Japanese\n"
@@ -16,7 +16,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: libskk/state.vala:776
+#: libskk/state.vala:834
+msgid "Kuten([M-][K]K-[T]T) "
+msgstr "区点([M-][K]K-[T]T) "
+
+#: libskk/state.vala:837
 msgid "Kuten([M]KKTT) "
 msgstr "区点([M]KKTT) "
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -6,49 +6,49 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: libskk 0.0.1\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-03-06 18:38+0900\n"
+"Report-Msgid-Bugs-To: ueno@gnu.org\n"
+"POT-Creation-Date: 2026-03-24 09:37+0900\n"
 "PO-Revision-Date: 2014-03-06 18:39+0900\n"
 "Last-Translator: Daiki Ueno <ueno@unixuser.org>\n"
 "Language-Team: Japanese\n"
-"Language: \n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../libskk/state.vala:649
-msgid "Kuten([MM]KKTT) "
-msgstr "区点([MM]KKTT) "
+#: libskk/state.vala:776
+msgid "Kuten([M]KKTT) "
+msgstr "区点([M]KKTT) "
 
-#: ../tools/skk.vala:28 ../tools/fep.vala:35
+#: tools/skk.vala:28 tools/fep.vala:35
 msgid "Path to a file dictionary"
 msgstr "ファイル辞書へのパス"
 
-#: ../tools/skk.vala:30 ../tools/fep.vala:37
+#: tools/skk.vala:30 tools/fep.vala:37
 msgid "Path to a user dictionary"
 msgstr "ユーザ辞書へのパス"
 
-#: ../tools/skk.vala:32 ../tools/fep.vala:39
+#: tools/skk.vala:32 tools/fep.vala:39
 msgid "Host and port running skkserv (HOST:PORT)"
 msgstr "skkserv が動いているホストとポート (HOST:PORT)"
 
-#: ../tools/skk.vala:34 ../tools/fep.vala:41
+#: tools/skk.vala:34 tools/fep.vala:41
 msgid "Typing rule (default: \"default\")"
 msgstr "タイピング方式 (既定値: \"default\")"
 
-#: ../tools/skk.vala:36 ../tools/fep.vala:43
+#: tools/skk.vala:36 tools/fep.vala:43
 msgid "List typing rules"
 msgstr "タイピング方式を一覧表示"
 
-#: ../tools/skk.vala:47 ../tools/fep.vala:56
+#: tools/skk.vala:47 tools/fep.vala:56
 msgid "- emulate SKK input method on the command line"
 msgstr "コマンドライン上で SKK 入力メソッドをエミュレート"
 
-#: ../tools/fep.vala:45
+#: tools/fep.vala:45
 msgid "Preedit style"
 msgstr "編集中のテキストのスタイル"
 
-#: ../tools/fep.vala:151
+#: tools/fep.vala:151
 #, c-format
 msgid "unknown preedit style %s"
 msgstr "未知のスタイル %s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -18,7 +18,7 @@ msgstr ""
 
 #: ../libskk/state.vala:649
 msgid "Kuten([MM]KKTT) "
-msgstr "区点([MM]KKTT)"
+msgstr "区点([MM]KKTT) "
 
 #: ../tools/skk.vala:28 ../tools/fep.vala:35
 msgid "Path to a file dictionary"

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -262,9 +262,13 @@ static SkkTransition dict_edit_transitions[] =
 
 static SkkTransition kuten_transitions[] =
   {
-    { SKK_INPUT_MODE_HIRAGANA, "\\\\", "Kuten([MM]KKTT) ", "", SKK_INPUT_MODE_HIRAGANA },
-    { SKK_INPUT_MODE_HIRAGANA, "\\\\ a DEL", "Kuten([MM]KKTT) ", "", SKK_INPUT_MODE_HIRAGANA },
-    { SKK_INPUT_MODE_HIRAGANA, "\\\\ a 1 a 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\", "Kuten([M]KKTT) ", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 DEL", "Kuten([M]KKTT) ", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 0 1 0 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
+    /* Explicit plane 1 (men) */
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 0 1 0 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
+    /* Plane 2 */
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 2 0 1 0 3 \n", "", "丏", SKK_INPUT_MODE_HIRAGANA },
     /* Don't start KUTEN input on latin input modes. */
     { SKK_INPUT_MODE_LATIN, "\\\\", "", "\\", SKK_INPUT_MODE_LATIN },
     { SKK_INPUT_MODE_WIDE_LATIN, "\\\\", "", "＼", SKK_INPUT_MODE_WIDE_LATIN },

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -263,12 +263,21 @@ static SkkTransition dict_edit_transitions[] =
 static SkkTransition kuten_transitions[] =
   {
     { SKK_INPUT_MODE_HIRAGANA, "\\\\", "Kuten([M]KKTT) ", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1", "Kuten([M]KKTT) 1", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 DEL", "Kuten([M]KKTT) ", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 0 1 0 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
     /* Explicit plane 1 (men) */
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 0 1 0 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
     /* Plane 2 */
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 2 0 1 0 3 \n", "", "丏", SKK_INPUT_MODE_HIRAGANA },
+    /* Hyphenated kuten */
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 -", "Kuten([M-][K]K-[T]T) 1-", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 2 -", "Kuten([M-][K]K-[T]T) 12-", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 - DEL DEL", "Kuten([M]KKTT) ", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 - 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 - 1 - 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 - 0 1 - 0 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ 2 - 1 - 3 \n", "", "丏", SKK_INPUT_MODE_HIRAGANA },
     /* Don't start KUTEN input on latin input modes. */
     { SKK_INPUT_MODE_LATIN, "\\\\", "", "\\", SKK_INPUT_MODE_LATIN },
     { SKK_INPUT_MODE_WIDE_LATIN, "\\\\", "", "＼", SKK_INPUT_MODE_WIDE_LATIN },


### PR DESCRIPTION
This fixes #113, and may make kuten mode behavior more compatible with existing other implementations.

By this patch, kuten mode now:

* accepts non-hyphenated decimal kuten (such as `0102` or `10102` for 1-01-02 `、`).
* accepts hyphenated decimal kuten (such as `1-2`, `01-02`, `1-1-2`, or `1-01-02` for 1-01-02 `、`).
    + Note that this patch always expects men (plane) to be single digit, so `01-01-02` won't be accepted.
* rejects hexadecimal EUC-JP binary representation (previously accepted input)
    + now `a1a2` won't be interpreted as `0xA1 0xA2` in EUC-JP (i.e., `、`), and in the first place a hexadecimal digit (`a` in this case) will simply be ignored.