### PR TITLE
Reset henkan auto-starter by abort commands

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -1126,6 +1126,7 @@ namespace Skk {
                      command == "abort-to-latin-unhandled") {
                 state.candidates.clear ();
                 state.cancel_okuri ();
+                state.auto_start_henkan_keyword = null;
                 if (state.abbrev.len > 0) {
                     state.handler_type = typeof (AbbrevStateHandler);
                 } else {

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -276,6 +276,10 @@ static SkkTransition auto_conversion_transitions[] = {
     { SKK_INPUT_MODE_HIRAGANA, "A i , SPC", "▼哀、", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "A i w o", "▼愛を", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "A i SPC \\(", "", "愛(", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "A i , C-g", "▽あい", "", SKK_INPUT_MODE_HIRAGANA },
+    /* Abort command should discard the previous auto conversion starter */
+    { SKK_INPUT_MODE_HIRAGANA, "A i , C-g SPC", "▼愛", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "A i , C-g SPC a", "", "愛あ", SKK_INPUT_MODE_HIRAGANA },
     { 0, NULL }
   };
 


### PR DESCRIPTION
After cancelling the auto-started conversion, the conversion auto-starter remains internally, and it unexpectedly revives at the next attempt of conversion even if it is started by SPC (usually `next-candidate` command).

## Steps to reproduce

1. Run `echo 'A o . C-g SPC' | ./tools/skk`

## Expected Result
`{ "input": "A o . C-g SPC", "output": "", "preedit": "▼青" }`

Henkan auto start by `.` is cancelled and `。` does not appear at the second attempt of conversion.

## Actual result
`{ "input": "A o . C-g SPC", "output": "", "preedit": "▼青。" }`

A state of auto-started henkan remains after abort command by `C-g`, so the second attempt of conversion by `SPC` adds extra `。`.