### PR TITLE
Support Unicode code point in Kuten mode

### DIFF
--- a/libskk/state.vala
+++ b/libskk/state.vala
@@ -171,6 +171,9 @@ namespace Skk {
                     |
                     # [D-][D]D-[D]D ([M-][K]K-[T]T)
                     ^(?:(?P<men>\d)-)?(?P<ku>\d{1,2})-(?P<ten>\d{1,2})$
+                    |
+                    # u[HHHHH]H (u<Unicode_Scalar_Value>)
+                    ^u(?P<usv>[0-9A-Fa-f]{1,6})$
                     """,
                     RegexCompileFlags.EXTENDED | RegexCompileFlags.DUPNAMES);
             } catch (GLib.RegexError e) {
@@ -767,8 +770,31 @@ namespace Skk {
                     warning ("can't decode %s in EUC-JP: %s",
                              euc_builder.str, e.message);
                 }
+                return null;
             }
-            return null;
+
+            info.fetch_named_pos ("usv",
+                                  out start_pos,
+                                  out end_pos);
+            if (start_pos >= 0) {
+                // format:
+                //  * u[HHHHH]H
+                unichar uc = 0;
+                for (int i = start_pos; i < end_pos; i++) {
+                    uc = uc * 16 + state.kuten.str[i].xdigit_value ();
+                }
+                if (uc.validate ()) {
+                    var builder = new StringBuilder ();
+                    builder.append_unichar (uc);
+                    return builder.str;
+                }
+                else {
+                    warning ("invalid Unicode character U+%04X", uc);
+                    return null;
+                }
+            }
+
+            assert_not_reached ();
         }
 
         int hex_char_to_int (char hex) {
@@ -829,7 +855,10 @@ namespace Skk {
                                               out uint underline_offset,
                                               out uint underline_nchars) {
             underline_offset = underline_nchars = 0;
-            if ((state.kuten.len >= 2 && state.kuten.str[1] == '-') ||
+            if (state.kuten.len >= 1 && state.kuten.str[0] == 'u') {
+                return _("Unicode(u[HHHHH]H) ") + state.kuten.str;
+            }
+            else if ((state.kuten.len >= 2 && state.kuten.str[1] == '-') ||
                 (state.kuten.len >= 3 && state.kuten.str[2] == '-')) {
                 return _("Kuten([M-][K]K-[T]T) ") + state.kuten.str;
             }

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libskk 0.0.1\n"
 "Report-Msgid-Bugs-To: ueno@gnu.org\n"
-"POT-Creation-Date: 2026-03-24 09:39+0900\n"
+"POT-Creation-Date: 2026-03-24 09:41+0900\n"
 "PO-Revision-Date: 2014-03-06 18:39+0900\n"
 "Last-Translator: Daiki Ueno <ueno@unixuser.org>\n"
 "Language-Team: Japanese\n"
@@ -16,11 +16,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: libskk/state.vala:834
+#: libskk/state.vala:859
+msgid "Unicode(u[HHHHH]H) "
+msgstr "Unicode(u[HHHHH]H) "
+
+#: libskk/state.vala:863
 msgid "Kuten([M-][K]K-[T]T) "
 msgstr "区点([M-][K]K-[T]T) "
 
-#: libskk/state.vala:837
+#: libskk/state.vala:866
 msgid "Kuten([M]KKTT) "
 msgstr "区点([M]KKTT) "
 

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -263,14 +263,15 @@ static SkkTransition dict_edit_transitions[] =
 static SkkTransition kuten_transitions[] =
   {
     { SKK_INPUT_MODE_HIRAGANA, "\\\\", "Kuten([M]KKTT) ", "", SKK_INPUT_MODE_HIRAGANA },
+    /* JIS kuten */
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1", "Kuten([M]KKTT) 1", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 DEL", "Kuten([M]KKTT) ", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 0 1 0 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
-    /* Explicit plane 1 (men) */
+    /* JIS kuten, explicit plane 1 (men) */
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 0 1 0 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
-    /* Plane 2 */
+    /* JIS kuten, plane 2 */
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 2 0 1 0 3 \n", "", "丏", SKK_INPUT_MODE_HIRAGANA },
-    /* Hyphenated kuten */
+    /* JIS kuten, hyphenated */
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 -", "Kuten([M-][K]K-[T]T) 1-", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 2 -", "Kuten([M-][K]K-[T]T) 12-", "", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 - DEL DEL", "Kuten([M]KKTT) ", "", SKK_INPUT_MODE_HIRAGANA },
@@ -278,6 +279,13 @@ static SkkTransition kuten_transitions[] =
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 - 1 - 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 1 - 0 1 - 0 2 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
     { SKK_INPUT_MODE_HIRAGANA, "\\\\ 2 - 1 - 3 \n", "", "丏", SKK_INPUT_MODE_HIRAGANA },
+    /* Unicode Scalar Value */
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ u", "Unicode(u[HHHHH]H) u", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ u F", "Unicode(u[HHHHH]H) uF", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ u f", "Unicode(u[HHHHH]H) uf", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ u f DEL", "Unicode(u[HHHHH]H) u", "", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ u 3 0 0 1 \n", "", "、", SKK_INPUT_MODE_HIRAGANA },
+    { SKK_INPUT_MODE_HIRAGANA, "\\\\ u 1 f 3 7 A \n", "", "🍺", SKK_INPUT_MODE_HIRAGANA },
     /* Don't start KUTEN input on latin input modes. */
     { SKK_INPUT_MODE_LATIN, "\\\\", "", "\\", SKK_INPUT_MODE_LATIN },
     { SKK_INPUT_MODE_WIDE_LATIN, "\\\\", "", "＼", SKK_INPUT_MODE_WIDE_LATIN },


### PR DESCRIPTION
This patch adds a support for Unicode code point at Kuten mode.
For example, `backslash u 1 f 3 7 a RET` will emit U+1F37A BEER MUG `🍺`.

```
$ echo 'backslash u 1 f 3 7 a RET' | skk
{ "input": "backslash u 1 f 3 7 a RET", "output": "🍺", "preedit": "" }
$
```